### PR TITLE
Add support for setting keep accessory power & low power mode settings

### DIFF
--- a/tessie_api/__init__.py
+++ b/tessie_api/__init__.py
@@ -42,6 +42,8 @@ from .horn import honk
 from .idles import get_idles
 from .keyless_driving import enable_keyless_driving
 from .lights import flash_lights
+from .low_power_mode import enable_low_power_mode
+from .low_power_mode import disable_low_power_mode
 from .scheduling import set_scheduled_charging
 from .scheduling import set_scheduled_departure
 from .sentry_mode import enable_sentry_mode

--- a/tessie_api/__init__.py
+++ b/tessie_api/__init__.py
@@ -1,3 +1,5 @@
+from .accessory_power import enable_keep_accessory_power_mode
+from .accessory_power import disable_keep_accessory_power_mode
 from .battery_health import get_battery_health
 from .battery import get_battery
 from .boombox import boombox

--- a/tessie_api/accessory_power.py
+++ b/tessie_api/accessory_power.py
@@ -1,0 +1,41 @@
+import aiohttp
+from typing import Any, Dict
+from .tessie_wrapper import tessieRequest
+
+
+async def enable_keep_accessory_power_mode(
+    session: aiohttp.ClientSession,
+    vin: str,
+    api_key: str,
+    max_attempts: int = 3,
+    wait_for_completion: bool = True,
+) -> Dict[str, Any]:
+    return await tessieRequest(
+        session,
+        "POST",
+        f"/{vin}/command/enable_keep_accessory_power_mode",
+        api_key,
+        params={
+            "max_attempts": max_attempts,
+            "wait_for_completion": str(wait_for_completion).lower(),
+        },
+    )
+
+
+async def disable_keep_accessory_power_mode(
+    session: aiohttp.ClientSession,
+    vin: str,
+    api_key: str,
+    max_attempts: int = 3,
+    wait_for_completion: bool = True,
+) -> Dict[str, Any]:
+    return await tessieRequest(
+        session,
+        "POST",
+        f"/{vin}/command/disable_keep_accessory_power_mode",
+        api_key,
+        params={
+            "max_attempts": max_attempts,
+            "wait_for_completion": str(wait_for_completion).lower(),
+        },
+    )

--- a/tessie_api/low_power_mode.py
+++ b/tessie_api/low_power_mode.py
@@ -1,0 +1,41 @@
+import aiohttp
+from typing import Any, Dict
+from .tessie_wrapper import tessieRequest
+
+
+async def enable_low_power_mode(
+    session: aiohttp.ClientSession,
+    vin: str,
+    api_key: str,
+    max_attempts: int = 3,
+    wait_for_completion: bool = True,
+) -> Dict[str, Any]:
+    return await tessieRequest(
+        session,
+        "POST",
+        f"/{vin}/command/enable_low_power_mode",
+        api_key,
+        params={
+            "max_attempts": max_attempts,
+            "wait_for_completion": str(wait_for_completion).lower(),
+        },
+    )
+
+
+async def disable_low_power_mode(
+    session: aiohttp.ClientSession,
+    vin: str,
+    api_key: str,
+    max_attempts: int = 3,
+    wait_for_completion: bool = True,
+) -> Dict[str, Any]:
+    return await tessieRequest(
+        session,
+        "POST",
+        f"/{vin}/command/disable_low_power_mode",
+        api_key,
+        params={
+            "max_attempts": max_attempts,
+            "wait_for_completion": str(wait_for_completion).lower(),
+        },
+    )


### PR DESCRIPTION
This PR adds support for the following API endpoints

https://developer.tessie.com/reference/enable-keep-accessory-power-mode
https://developer.tessie.com/reference/disable-keep-accessory-power-mode
https://developer.tessie.com/reference/enable-low-power-mode
https://developer.tessie.com/reference/disable-low-power-mode

There is currently not a way I can find to get the status of these two settings via Tessie's API, and my investigation into the fleet API also turned up nothing. As a result these are just setter calls until a way to get the states can be found or added upstream.